### PR TITLE
Fixed issue with 'cd' explanation. Added 'pwd'

### DIFF
--- a/projects/command_prompt.html
+++ b/projects/command_prompt.html
@@ -95,11 +95,11 @@
 
 <p><code>ls</code> = lists the current files in the current directory</p>
 
-<p><code>cd</code> = &ldquo;current directory&rdquo; (displays your current path)</p>
+<p><code>pwd</code> = &ldquo;print working directory&rdquo; (displays the current directory path)</p>
+
+<p><code>cd &lt;directory_name&gt;</code> = &ldquo;change directory&rdquo; moves into the named directory</p>
 
 <p><code>cd ..</code> = Moves up one directory</p>
-
-<p><code>cd &lt;directory_name&gt;</code> = moves into the named directory</p>
 
 <p><code>mkdir &lt;directory_name&gt;</code> = creates a new directory</p>
 


### PR DESCRIPTION
The instructions for `cd` seemed to really imply `pwd`, so I changed that definition to that.   `cd` without an argument changes to the home directory, which is probably confusing.  

I switched the order of `cd ..` and `cd directory`, as its easier to explain how to switch _into_ a directory, and then how to switch out of it.   If this makes sense, go for it.
